### PR TITLE
Added first part of Debian/Ubuntu Detection

### DIFF
--- a/debian/modules/installjailkit.sh
+++ b/debian/modules/installjailkit.sh
@@ -2,6 +2,10 @@
 # Function: InstallJailkit
 #    Install Jailkit
 #---------------------------------------------------------------------
+
+#Program Versions
+JKV="2.17"  #Jailkit Version -> Maybe this can be automated
+
 InstallJailkit() {
   echo -n "Installing Jailkit... "
   apt-get -y install build-essential autoconf automake1.9 libtool flex bison debhelper > /dev/null 2>&1

--- a/debian/modules/preinstallcheck.sh
+++ b/debian/modules/preinstallcheck.sh
@@ -54,7 +54,7 @@ fi
 echo "Your Distro is:" --->>> $DISTRO
 read -p "Is this correct? " -n 1 -r
 echo    # (optional) move to a new line
-if [[ ! $REPLY =~ ^[Nn]$ ]]
+if [[ ! $REPLY =~ ^[Yy]$ ]]
 then
     exit 1
 fi

--- a/debian/modules/preinstallcheck.sh
+++ b/debian/modules/preinstallcheck.sh
@@ -32,14 +32,14 @@ PreInstallCheck() {
 
 # Debian Wheezy Detection
 if command -v lsb_release &> /dev/null; then
-	if lsb_release -a 2> /dev/null | grep -iq "Debian GNU/Linux 7.8"; then
+	if lsb_release -a 2> /dev/null | grep -iq "wheezy"; then
 		DISTRO=wheezy
 	fi
 fi
 
 # Debian Wheezy Detection
 if command -v lsb_release &> /dev/null; then
-	if lsb_release -a 2> /dev/null | grep -iq "Debian GNU/Linux 8.0"; then
+	if lsb_release -a 2> /dev/null | grep -iq "jessie"; then
 		DISTRO=jessie
 	fi
 fi

--- a/debian/modules/preinstallcheck.sh
+++ b/debian/modules/preinstallcheck.sh
@@ -28,20 +28,33 @@ PreInstallCheck() {
   echo -e "${green}OK${NC}\n"
 }
 
-# Functions For Detecting Current Distribution
+# Detect currect Linux Version
 
-# Debian Detection (LSB Release)
+# Debian Wheezy Detection
 if command -v lsb_release &> /dev/null; then
-	if lsb_release -a 2> /dev/null | grep -iq "debian"; then
-		# Set Distribution To Debian
-		DISTRIBUTION=debian
+	if lsb_release -a 2> /dev/null | grep -iq "Debian GNU/Linux 7.8"; then
+		DISTRO=wheezy
 	fi
 fi
 
-# Ubuntu Detection (LSB Release)
+# Debian Wheezy Detection
+if command -v lsb_release &> /dev/null; then
+	if lsb_release -a 2> /dev/null | grep -iq "Debian GNU/Linux 8.0"; then
+		DISTRO=jessie
+	fi
+fi
+
+# Ubuntu Detection
 if command -v lsb_release &> /dev/null; then
 	if lsb_release -a 2> /dev/null | grep -iq "ubuntu"; then
-		# Set Distribution To Ubuntu
-		DISTRIBUTION=ubuntu
+		DISTRO=ubuntu
 	fi
+fi
+
+echo "Your Distro is:" --->>> $DISTRO
+read -p "Is this correct? " -n 1 -r
+echo    # (optional) move to a new line
+if [[ ! $REPLY =~ ^[Nn]$ ]]
+then
+    exit 1
 fi

--- a/install.sh
+++ b/install.sh
@@ -26,8 +26,6 @@ red='\033[0;31m'
 green='\033[0;32m'
 NC='\033[0m' # No Color
 
-#Program Versions
-JKV="2.17"  #Jailkit Version -> Maybe this can be automated
 
 #Saving current directory
 PWD=$(pwd);
@@ -39,6 +37,11 @@ if [ $(id -u) != "0" ]; then
     echo "${red}Error:${red} You must be root to run this script. Please switch to root user to install ispconfig3 and needed software."
     exit 1
 fi
+
+#---------------------------------------------------------------------
+# Load needed Modules
+#---------------------------------------------------------------------
+
 
 include $PWD/debian/modules/installbasics.sh
 include $PWD/debian/modules/preinstallcheck.sh


### PR DESCRIPTION
New Load order for Modules, because lsb-release must be installed, before precheck
Merge remote-tracking branch 'upstream/v.1.0.6' into v.1.0.6