### PR TITLE
Fix config change for postfix

### DIFF
--- a/distros/ubuntu-16.04/install_postfix.sh
+++ b/distros/ubuntu-16.04/install_postfix.sh
@@ -14,11 +14,11 @@ InstallPostfix() {
   echo "postfix postfix/main_mailer_type select Internet Site" | debconf-set-selections
   echo "postfix postfix/mailname string $CFG_HOSTNAME_FQDN" | debconf-set-selections
   apt-get -yqq install postfix postfix-mysql postfix-doc getmail4 > /dev/null 2>&1
-  sed -i "s/#submission inet n       -       -       -       -       smtpd/submission inet n       -       -       -       -       smtpd/" /etc/postfix/master.cf
+  sed -i "s/#submission inet n       -       y       -       -       smtpd/submission inet n       -       y       -       -       smtpd/" /etc/postfix/master.cf
   sed -i "s/#  -o syslog_name=postfix\/submission/  -o syslog_name=postfix\/submission/" /etc/postfix/master.cf
   sed -i "s/#  -o smtpd_tls_security_level=encrypt/  -o smtpd_tls_security_level=encrypt/" /etc/postfix/master.cf
   sed -i "s/#  -o smtpd_sasl_auth_enable=yes/  -o smtpd_sasl_auth_enable=yes\n  -o smtpd_client_restrictions=permit_sasl_authenticated,reject/" /etc/postfix/master.cf
-  sed -i "s/#smtps     inet  n       -       -       -       -       smtpd/smtps     inet  n       -       -       -       -       smtpd/" /etc/postfix/master.cf
+  sed -i "s/#smtps     inet  n       -       y       -       -       smtpd/smtps     inet  n       -       y       -       -       smtpd/" /etc/postfix/master.cf
   sed -i "s/#  -o syslog_name=postfix\/smtps/  -o syslog_name=postfix\/smtps/" /etc/postfix/master.cf
   sed -i "s/#  -o smtpd_tls_wrappermode=yes/  -o smtpd_tls_wrappermode=yes/" /etc/postfix/master.cf
   sed -i "s/#  -o smtpd_sasl_auth_enable=yes/  -o smtpd_sasl_auth_enable=yes\n  -o smtpd_client_restrictions=permit_sasl_authenticated,reject/" /etc/postfix/master.cf


### PR DESCRIPTION
The master.cf has changed in the Ubuntu package
The "y" for chroot is missing in the sed-line and so the sed failed
The consequence is that postfix doesnt receiving any mails

See also the master.cf.dist from Ubuntu 16.04:
https://paste.debian.net/plain/854678