### PR TITLE
[BUGFIX] add missing backports repo to apt sources

### DIFF
--- a/distros/debian8/install_basics.sh
+++ b/distros/debian8/install_basics.sh
@@ -3,6 +3,7 @@
 #    Install basic packages
 #---------------------------------------------------------------------
 InstallBasics() {
+  echo 'deb http://ftp.debian.org/debian jessie-backports main' > /etc/apt/sources.list
   echo -n "Updating apt and upgrading currently installed packages... "
   apt-get -qq update > /dev/null 2>&1
   apt-get -qqy upgrade > /dev/null 2>&1


### PR DESCRIPTION
fix an error where install_webserver.sh was missing an apt source.