### PR TITLE
Fix missing certbot-auto command

### DIFF
--- a/distros/debian8/install_webserver.sh
+++ b/distros/debian8/install_webserver.sh
@@ -102,7 +102,7 @@ InstallWebServer() {
 	echo "Press ENTER to continue... "
 	read DUMMY
 	echo -n "Installing Certbot-auto... "
-	certbot-auto
+	certbot
 	echo -e "[${green}DONE${NC}]\n"
   
   fi


### PR DESCRIPTION
The [patch you made 8 days ago](https://github.com/servisys/ispconfig_setup/commit/e4d33cde0ffc05b6b29bf7dcd9fa72f359c0ae42) was actually missing that line too.