### PR TITLE
Allow variables to be predefined

### DIFF
--- a/distros/debian8/askquestions.sh
+++ b/distros/debian8/askquestions.sh
@@ -8,72 +8,95 @@ AskQuestions() {
 	  CFG_SETUP_NS=yes #Needed for Multiserver setup compatibility
 	  echo "Installing pre-required packages"
 	  [ -f /bin/whiptail ] && echo -e "whiptail found: ${green}OK${NC}\n"  || apt-get -y install whiptail > /dev/null 2>&1
-	  
+
 	  while [ "x$CFG_SQLSERVER" == "x" ]
-          do
-                CFG_SQLSERVER=$(whiptail --title "SQLSERVER" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "Select SQL Server type" 10 50 2 "MySQL" "(default)" ON "MariaDB" "" OFF 3>&1 1>&2 2>&3)
-          done
-		  
+		  do
+				CFG_SQLSERVER=$(whiptail --title "SQLSERVER" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "Select SQL Server type" 10 50 2 "MySQL" "(default)" ON "MariaDB" "" OFF 3>&1 1>&2 2>&3)
+		  done
+
 	  while [ "x$CFG_MYSQL_ROOT_PWD" == "x" ]
-	  do
-		CFG_MYSQL_ROOT_PWD=$(whiptail --title "MySQL" --backtitle "$WT_BACKTITLE" --inputbox "Please specify a root password" --nocancel 10 50 3>&1 1>&2 2>&3)
-	  done
+		  do
+			CFG_MYSQL_ROOT_PWD=$(whiptail --title "MySQL" --backtitle "$WT_BACKTITLE" --inputbox "Please specify a root password" --nocancel 10 50 3>&1 1>&2 2>&3)
+		  done
 
 	  while [ "x$CFG_WEBSERVER" == "x" ]
-          do
-                CFG_WEBSERVER=$(whiptail --title "WEBSERVER" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "Select webserver type" 10 50 2 "apache" "(default)" ON "nginx" "" OFF 3>&1 1>&2 2>&3)
-          done
-	  
+		  do
+				CFG_WEBSERVER=$(whiptail --title "WEBSERVER" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "Select webserver type" 10 50 2 "apache" "(default)" ON "nginx" "" OFF 3>&1 1>&2 2>&3)
+		  done
+
 	  while [ "x$CFG_HHVM" == "x" ]
-          do
-                CFG_HHVM=$(whiptail --title "HHVM" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "Do you want to install HHVM?" 10 50 2 "no" "(default)" ON "yes" "" OFF 3>&1 1>&2 2>&3)
-          done
-	
+		  do
+				CFG_HHVM=$(whiptail --title "HHVM" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "Do you want to install HHVM?" 10 50 2 "no" "(default)" ON "yes" "" OFF 3>&1 1>&2 2>&3)
+		  done
+
 	  while [ "x$CFG_XCACHE" == "x" ]
 		  do
 				CFG_XCACHE=$(whiptail --title "Install XCache" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "You want to install XCache during install? ATTENTION: If XCache is installed, Ioncube Loaders will not work !!" 20 50 2 "yes" "(default)" ON "no" "" OFF 3>&1 1>&2 2>&3)
-	  done
-	
+		 done
+
 	  while [ "x$CFG_PHPMYADMIN" == "x" ]
 		  do
 				CFG_PHPMYADMIN=$(whiptail --title "Install phpMyAdmin" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "You want to install phpMyAdmin during install?" 10 50 2 "yes" "(default)" ON "no" "" OFF 3>&1 1>&2 2>&3)
-	  done
-	
+		 done
+
 	  while [ "x$CFG_MTA" == "x" ]
-	  do
-		CFG_MTA=$(whiptail --title "Mail Server" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "Select mailserver type" 10 50 2 "dovecot" "(default)" ON "courier" "" OFF 3>&1 1>&2 2>&3)
-	  done
+		  do
+			CFG_MTA=$(whiptail --title "Mail Server" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "Select mailserver type" 10 50 2 "dovecot" "(default)" ON "courier" "" OFF 3>&1 1>&2 2>&3)
+		  done
 
 	  while [ "x$CFG_AVUPDATE" == "x" ]
-	  do
-		CFG_AVUPDATE=$(whiptail --title "Update Freshclam DB" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "You want to update Antivirus Database during install?" 10 50 2 "yes" "(default)" ON "no" "" OFF 3>&1 1>&2 2>&3)
-	  done
-	  
-	  if (whiptail --title "Quota" --backtitle "$WT_BACKTITLE" --yesno "Setup user quota?" 10 50) then
-		CFG_QUOTA=yes
-	  else
-		CFG_QUOTA=no
-	  fi
-	
-	  while [ "x$CFG_ISPC" == "x" ]
-	  do
-          	CFG_ISPC=$(whiptail --title "ISPConfig Setup" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "Would you like full unattended setup of expert mode for ISPConfig?" 10 50 2 "standard" "(default)" ON "expert" "" OFF 3>&1 1>&2 2>&3)
-      done
+		  do
+			CFG_AVUPDATE=$(whiptail --title "Update Freshclam DB" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "You want to update Antivirus Database during install?" 10 50 2 "yes" "(default)" ON "no" "" OFF 3>&1 1>&2 2>&3)
+		  done
 
-	  if (whiptail --title "Jailkit" --backtitle "$WT_BACKTITLE" --yesno "Would you like to install Jailkit?" 10 50) then
-		CFG_JKIT=yes
-	  else
-		CFG_JKIT=no
-	  fi
+	  while [ "x$CFG_QUOTA" == "x" ]
+		  do
+			CFG_QUOTA=$(whiptail --title "Quota" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "Setup user quota?" 10 50 2 "yes" "(default)" ON "no" "" OFF 3>&1 1>&2 2>&3)
+		  done
+
+	  while [ "x$CFG_ISPC" == "x" ]
+		  do
+				CFG_ISPC=$(whiptail --title "ISPConfig Setup" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "Would you like full unattended setup of expert mode for ISPConfig?" 10 50 2 "standard" "(default)" ON "expert" "" OFF 3>&1 1>&2 2>&3)
+		  done
+
+	  while [ "x$CFG_JKIT" == "x" ]
+		  do
+				CFG_JKIT=$(whiptail --title "Jailkit" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "Would you like to install Jailkit?" 10 50 2 "yes" "(default)" ON "no" "" OFF 3>&1 1>&2 2>&3)
+		  done
 
 	  while [ "x$CFG_WEBMAIL" == "x" ]
-	  do
-		CFG_WEBMAIL=$(whiptail --title "Webmail client" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "Select your webmail client" 10 50 2 "roundcube" "(default)" ON "squirrelmail" "" OFF 3>&1 1>&2 2>&3)
-	  done
-	  
-	  SSL_COUNTRY=$(whiptail --title "SSL Country" --backtitle "$WT_BACKTITLE" --inputbox "SSL Configuration - Country (ex. EN)" --nocancel 10 50 3>&1 1>&2 2>&3)
-      SSL_STATE=$(whiptail --title "SSL State" --backtitle "$WT_BACKTITLE" --inputbox "SSL Configuration - STATE (ex. Italy)" --nocancel 10 50 3>&1 1>&2 2>&3)
-      SSL_LOCALITY=$(whiptail --title "SSL Locality" --backtitle "$WT_BACKTITLE" --inputbox "SSL Configuration - Locality (ex. Udine)" --nocancel 10 50 3>&1 1>&2 2>&3)
-      SSL_ORGANIZATION=$(whiptail --title "SSL Organization" --backtitle "$WT_BACKTITLE" --inputbox "SSL Configuration - Organization (ex. Company L.t.d.)" --nocancel 10 50 3>&1 1>&2 2>&3)
-      SSL_ORGUNIT=$(whiptail --title "SSL Organization Unit" --backtitle "$WT_BACKTITLE" --inputbox "SSL Configuration - Organization Unit (ex. IT Department)" --nocancel 10 50 3>&1 1>&2 2>&3)
+		  do
+			CFG_WEBMAIL=$(whiptail --title "Webmail client" --backtitle "$WT_BACKTITLE" --nocancel --radiolist "Select your webmail client" 10 50 2 "roundcube" "(default)" ON "squirrelmail" "" OFF 3>&1 1>&2 2>&3)
+		  done
+
+	  while [ "x$SSL_COUNTRY" == "x" ]
+		  do
+			SSL_COUNTRY=$(whiptail --title "SSL Country" --backtitle "$WT_BACKTITLE" --inputbox "SSL Configuration - Country (ex. EN)" --nocancel 10 50 3>&1 1>&2 2>&3)
+		  done
+
+	  while [ "x$SSL_STATE" == "x" ]
+		  do
+			SSL_STATE=$(whiptail --title "SSL State" --backtitle "$WT_BACKTITLE" --inputbox "SSL Configuration - STATE (ex. Italy)" --nocancel 10 50 3>&1 1>&2 2>&3)
+		  done
+
+	  while [ "x$SSL_LOCALITY" == "x" ]
+		  do
+			SSL_LOCALITY=$(whiptail --title "SSL Locality" --backtitle "$WT_BACKTITLE" --inputbox "SSL Configuration - Locality (ex. Udine)" --nocancel 10 50 3>&1 1>&2 2>&3)
+		  done
+
+	  while [ "x$SSL_ORGANIZATION" == "x" ]
+		  do
+			SSL_ORGANIZATION=$(whiptail --title "SSL Organization" --backtitle "$WT_BACKTITLE" --inputbox "SSL Configuration - Organization (ex. Company L.t.d.)" --nocancel 10 50 3>&1 1>&2 2>&3)
+		  done
+
+	  while [ "x$SSL_ORGUNIT" == "x" ]
+		  do
+			SSL_ORGUNIT=$(whiptail --title "SSL Organization Unit" --backtitle "$WT_BACKTITLE" --inputbox "SSL Configuration - Organization Unit (ex. IT Department)" --nocancel 10 50 3>&1 1>&2 2>&3)
+		  done
+
+
+
+
+
+
 }

--- a/distros/debian8/install_mysql.sh
+++ b/distros/debian8/install_mysql.sh
@@ -19,7 +19,7 @@ InstallSQLServer() {
     echo "mysql-server-5.5 mysql-server/root_password_again password $CFG_MYSQL_ROOT_PWD" | debconf-set-selections
     apt-get -y install mariadb-client mariadb-server > /dev/null 2>&1
     sed -i 's/bind-address		= 127.0.0.1/#bind-address		= 127.0.0.1/' /etc/mysql/my.cnf
-    service mysql restart /dev/null 2>&1
+    service mysql restart > /dev/null 2>&1
     echo -e "[${green}DONE${NC}]\n"
   fi	
 }


### PR DESCRIPTION
Hello

I intend to use this script for an automated installation of ISPconfig in a docker container.
To get it working I needed to streamline some of the variable definitions, so it will prevent dialogs from showing up if these variables are already set.

It also fixes a small bug in the mysql script, where mysql tries to start up and then fails after a while.

With these changes, a fully unattended installation (in debian 8 and with most of the default settings) worked for me, although I still got some minor warnings here and there. But this might also be docker-specific issues, which I will analyse soon.

Thanks and keep up the good work!