### PR TITLE
pureftpd renamed to pure-ftpd, which is the actual filter

### DIFF
--- a/distros/debian9/install_fail2ban.sh
+++ b/distros/debian9/install_fail2ban.sh
@@ -80,7 +80,7 @@ cat >> /etc/fail2ban/jail.local <<EOF
 [pureftpd]
 enabled = true
 port = ftp
-filter = pureftpd
+filter = pure-ftpd
 logpath = /var/log/syslog
 maxretry = 3
 


### PR DESCRIPTION
The filter delivered by fail2ban is called pure-ftpd.conf in /etc/fail2ban/filter.d

the install script for fail2ban points to pureftpd (without the dash). 

Issue #244 can be closed.