### PR TITLE
fixing typo on install scripts

### DIFF
--- a/distros/centos7/install_mta.sh
+++ b/distros/centos7/install_mta.sh
@@ -5,14 +5,14 @@
 InstallMTA() {
   case $CFG_MTA in
 	"courier")
-	  echo -n "Installing SMTP Mail server (Courier)... ";
+	  echo -n "Installing POP3/IMAP Mail server (Courier)... ";
 	  echo -e "\n${red}Sorry but Courier is not yet supported.${NC}" >&2
 	  echo -e "For more information, see this issue: https://github.com/servisys/ispconfig_setup/issues/70\n"
 	  echo "Press ENTER"
 	  read DUMMY
 	  ;;
 	"dovecot")
-	  echo -n "Installing SMTP Mail server (Dovecot)... ";
+	  echo -n "Installing POP3/IMAP Mail server (Dovecot)... ";
 	  yum_install dovecot dovecot-mysql dovecot-pigeonhole
 	  touch /etc/dovecot/dovecot-sql.conf
 	  ln -s /etc/dovecot/dovecot-sql.conf /etc/dovecot-sql.conf

--- a/distros/centos7/install_postfix.sh
+++ b/distros/centos7/install_postfix.sh
@@ -7,7 +7,7 @@ InstallPostfix() {
   systemctl stop sendmail.service
   systemctl disable sendmail.service
   echo -e "[${green}DONE${NC}]\n"
-  echo -n "Installing POP3/IMAP Mail server (Postfix)... "
+  echo -n "Installing SMTP Mail server (Postfix)... "
   yum_install postfix ntp getmail
   #Fix for mailman virtualtable - need also without mailman
   mkdir /etc/mailman/

--- a/distros/debian7/install_mta.sh
+++ b/distros/debian7/install_mta.sh
@@ -5,7 +5,7 @@
 InstallMTA() {
   case $CFG_MTA in
 	"courier")
-	  echo -n "Installing SMTP Mail server (Courier)... ";
+	  echo -n "Installing POP3/IMAP Mail server (Courier)... ";
 	  echo "courier-base courier-base/webadmin-configmode boolean false" | debconf-set-selections
 	  echo "courier-ssl courier-ssl/certnotice note" | debconf-set-selections
 	  apt_install courier-authdaemon courier-authlib-mysql courier-pop courier-pop-ssl courier-imap courier-imap-ssl libsasl2-2 libsasl2-modules libsasl2-modules-sql sasl2-bin libpam-mysql courier-maildrop
@@ -28,7 +28,7 @@ InstallMTA() {
 	  echo -e "[${green}DONE${NC}]\n"
 	  ;;
 	"dovecot")
-	  echo -n "Installing SMTP Mail server (Dovecot)... ";
+	  echo -n "Installing POP3/IMAP Mail server (Dovecot)... ";
 	  apt_install dovecot-imapd dovecot-pop3d dovecot-mysql dovecot-sieve
 	  echo -e "[${green}DONE${NC}]\n"
 	  ;;

--- a/distros/debian7/install_postfix.sh
+++ b/distros/debian7/install_postfix.sh
@@ -10,7 +10,7 @@ InstallPostfix() {
 	apt_remove sendmail
 	echo -e "[${green}DONE${NC}]\n"
   fi
-  echo -n "Installing POP3/IMAP Mail server (Postfix)... "
+  echo -n "Installing SMTP Mail server (Postfix)... "
   echo "postfix postfix/main_mailer_type select Internet Site" | debconf-set-selections
   echo "postfix postfix/mailname string $CFG_HOSTNAME_FQDN" | debconf-set-selections
   apt_install postfix postfix-mysql postfix-doc getmail4

--- a/distros/debian8/install_mta.sh
+++ b/distros/debian8/install_mta.sh
@@ -5,7 +5,7 @@
 InstallMTA() {
   case $CFG_MTA in
 	"courier")
-	  echo -n "Installing SMTP Mail server (Courier) and Mail signing (OpenDKIM, OpenDMARC)... ";
+	  echo -n "Installing POP3/IMAP Mail server (Courier) and Mail signing (OpenDKIM, OpenDMARC)... ";
 	  echo "courier-base courier-base/webadmin-configmode boolean false" | debconf-set-selections
 	  echo "courier-ssl courier-ssl/certnotice note" | debconf-set-selections
 	  apt_install courier-authdaemon courier-authlib-mysql courier-pop courier-pop-ssl courier-imap courier-imap-ssl libsasl2-2 libsasl2-modules libsasl2-modules-sql sasl2-bin libpam-mysql courier-maildrop opendkim opendkim-tools opendmarc
@@ -28,7 +28,7 @@ InstallMTA() {
 	  echo -e "[${green}DONE${NC}]\n"
 	  ;;
 	"dovecot")
-	  echo -n "Installing SMTP Mail server (Dovecot) and Mail signing (OpenDKIM, OpenDMARC)... ";
+	  echo -n "Installing POP3/IMAP Mail server (Dovecot) and Mail signing (OpenDKIM, OpenDMARC)... ";
 	  apt_install dovecot-imapd dovecot-pop3d dovecot-mysql dovecot-sieve dovecot-lmtpd opendkim opendkim-tools opendmarc
 	  echo -e "[${green}DONE${NC}]\n"
 	  ;;

--- a/distros/debian8/install_postfix.sh
+++ b/distros/debian8/install_postfix.sh
@@ -11,7 +11,7 @@ InstallPostfix() {
 	echo -e "[${green}DONE${NC}]\n"
   fi
   
-  echo -n "Installing POP3/IMAP Mail server (Postfix)... "
+  echo -n "Installing SMTP Mail server (Postfix)... "
   echo "postfix postfix/main_mailer_type select Internet Site" | debconf-set-selections
   echo "postfix postfix/mailname string $CFG_HOSTNAME_FQDN" | debconf-set-selections
   apt_install postfix postfix-mysql postfix-doc getmail4

--- a/distros/debian9/install_mta.sh
+++ b/distros/debian9/install_mta.sh
@@ -3,7 +3,7 @@
 #    Install chosen MTA. Courier or Dovecot
 #---------------------------------------------------------------------
 InstallMTA() {
-  echo -n "Installing SMTP Mail server (Dovecot) and Mail signing (OpenDKIM, OpenDMARC)... ";
+  echo -n "Installing POP3/IMAP Mail server (Dovecot) and Mail signing (OpenDKIM, OpenDMARC)... ";
   apt_install dovecot-imapd dovecot-pop3d dovecot-mysql dovecot-sieve dovecot-lmtpd dovecot-managesieved dovecot-lucene dovecot-antispam opendkim opendkim-tools opendmarc
   echo -e "[${green}DONE${NC}]\n"
 }

--- a/distros/debian9/install_postfix.sh
+++ b/distros/debian9/install_postfix.sh
@@ -11,7 +11,7 @@ InstallPostfix() {
 	echo -e "[${green}DONE${NC}]\n"
   fi
   
-  echo -n "Installing POP3/IMAP Mail server (Postfix)... "
+  echo -n "Installing SMTP Mail server (Postfix)... "
   echo "postfix postfix/main_mailer_type select Internet Site" | debconf-set-selections
   echo "postfix postfix/mailname string $CFG_HOSTNAME_FQDN" | debconf-set-selections
   # apt_install postfix postfix-mysql postfix-doc getmail4

--- a/distros/ubuntu-14.04/install_mta.sh
+++ b/distros/ubuntu-14.04/install_mta.sh
@@ -5,7 +5,7 @@
 InstallMTA() {
   case $CFG_MTA in
 	"courier")
-	  echo -n "Installing SMTP Mail server (Courier) and Mail signing (OpenDKIM, OpenDMARC)... ";
+	  echo -n "Installing POP3/IMAP Mail server (Courier) and Mail signing (OpenDKIM, OpenDMARC)... ";
 	  echo "courier-base courier-base/webadmin-configmode boolean false" | debconf-set-selections
 	  echo "courier-ssl courier-ssl/certnotice note" | debconf-set-selections
 	  apt_install courier-authdaemon courier-authlib-mysql courier-pop courier-pop-ssl courier-imap courier-imap-ssl libsasl2-2 libsasl2-modules libsasl2-modules-sql sasl2-bin libpam-mysql courier-maildrop opendkim opendkim-tools opendmarc
@@ -28,7 +28,7 @@ InstallMTA() {
 	  echo -e "[${green}DONE${NC}]\n"
 	  ;;
 	"dovecot")
-	  echo -n "Installing SMTP Mail server (Dovecot) and Mail signing (OpenDKIM, OpenDMARC)... ";
+	  echo -n "Installing POP3/IMAP Mail server (Dovecot) and Mail signing (OpenDKIM, OpenDMARC)... ";
 	  echo "dovecot-core dovecot-core/create-ssl-cert boolean false" | debconf-set-selections
 	  echo "dovecot-core dovecot-core/ssl-cert-name string $CFG_HOSTNAME_FQDN" | debconf-set-selections
 	  apt_install dovecot-imapd dovecot-pop3d dovecot-sieve dovecot-mysql dovecot-lmtpd opendkim opendkim-tools opendmarc

--- a/distros/ubuntu-14.04/install_postfix.sh
+++ b/distros/ubuntu-14.04/install_postfix.sh
@@ -11,7 +11,7 @@ InstallPostfix() {
 	echo -e "[${green}DONE${NC}]\n"
   fi
   
-  echo -n "Installing POP3/IMAP Mail server (Postfix)... "
+  echo -n "Installing SMTP Mail server (Postfix)... "
   echo "postfix postfix/main_mailer_type select Internet Site" | debconf-set-selections
   echo "postfix postfix/mailname string $CFG_HOSTNAME_FQDN" | debconf-set-selections
   apt_install postfix postfix-mysql postfix-doc getmail4

--- a/distros/ubuntu-15.10/install_mta.sh
+++ b/distros/ubuntu-15.10/install_mta.sh
@@ -5,7 +5,7 @@
 InstallMTA() {
   case $CFG_MTA in
 	"courier")
-	  echo -n "Installing SMTP Mail server (Courier) and Mail signing (OpenDKIM, OpenDMARC)... ";
+	  echo -n "Installing POP3/IMAP Mail server (Courier) and Mail signing (OpenDKIM, OpenDMARC)... ";
 	  echo "courier-base courier-base/webadmin-configmode boolean false" | debconf-set-selections
 	  echo "courier-ssl courier-ssl/certnotice note" | debconf-set-selections
 	  apt_install courier-authdaemon courier-authlib-mysql courier-pop courier-pop-ssl courier-imap courier-imap-ssl libsasl2-2 libsasl2-modules libsasl2-modules-sql sasl2-bin libpam-mysql courier-maildrop opendkim opendkim-tools opendmarc
@@ -28,7 +28,7 @@ InstallMTA() {
 	  echo -e "[${green}DONE${NC}]\n"
 	  ;;
 	"dovecot")
-	  echo -n "Installing SMTP Mail server (Dovecot) and Mail signing (OpenDKIM, OpenDMARC)... ";
+	  echo -n "Installing POP3/IMAP Mail server (Dovecot) and Mail signing (OpenDKIM, OpenDMARC)... ";
 	  echo "dovecot-core dovecot-core/create-ssl-cert boolean false" | debconf-set-selections
 	  echo "dovecot-core dovecot-core/ssl-cert-name string $CFG_HOSTNAME_FQDN" | debconf-set-selections
 	  # apt_install dovecot-imapd dovecot-pop3d dovecot-sieve dovecot-mysql dovecot-lmtpd opendkim opendkim-tools opendmarc

--- a/distros/ubuntu-15.10/install_postfix.sh
+++ b/distros/ubuntu-15.10/install_postfix.sh
@@ -11,7 +11,7 @@ InstallPostfix() {
 	echo -e "[${green}DONE${NC}]\n"
   fi
   
-  echo -n "Installing POP3/IMAP Mail server (Postfix)... "
+  echo -n "Installing SMTP Mail server (Postfix)... "
   echo "postfix postfix/main_mailer_type select Internet Site" | debconf-set-selections
   echo "postfix postfix/mailname string $CFG_HOSTNAME_FQDN" | debconf-set-selections
   apt_install postfix postfix-mysql postfix-doc getmail4

--- a/distros/ubuntu-16.04/install_mta.sh
+++ b/distros/ubuntu-16.04/install_mta.sh
@@ -5,7 +5,7 @@
 InstallMTA() {
   case $CFG_MTA in
 	"courier")
-	  echo -n "Installing SMTP Mail server (Courier) and Mail signing (OpenDKIM, OpenDMARC)... ";
+	  echo -n "Installing POP3/IMAP Mail server (Courier) and Mail signing (OpenDKIM, OpenDMARC)... ";
 	  echo "courier-base courier-base/webadmin-configmode boolean false" | debconf-set-selections
 	  echo "courier-ssl courier-ssl/certnotice note" | debconf-set-selections
 	  apt_install courier-authdaemon courier-authlib-mysql courier-pop courier-pop-ssl courier-imap courier-imap-ssl libsasl2-2 libsasl2-modules libsasl2-modules-sql sasl2-bin libpam-mysql courier-maildrop opendkim opendkim-tools opendmarc
@@ -29,7 +29,7 @@ InstallMTA() {
 	  ;;
 	  
 	"dovecot")
-	  echo -n "Installing SMTP Mail server (Dovecot) and Mail signing (OpenDKIM, OpenDMARC)... ";
+	  echo -n "Installing POP3/IMAP Mail server (Dovecot) and Mail signing (OpenDKIM, OpenDMARC)... ";
 	  echo "dovecot-core dovecot-core/create-ssl-cert boolean false" | debconf-set-selections
 	  echo "dovecot-core dovecot-core/ssl-cert-name string $CFG_HOSTNAME_FQDN" | debconf-set-selections
 	  apt_install dovecot-imapd dovecot-pop3d dovecot-mysql dovecot-sieve dovecot-lmtpd opendkim opendkim-tools opendmarc

--- a/distros/ubuntu-16.04/install_postfix.sh
+++ b/distros/ubuntu-16.04/install_postfix.sh
@@ -11,7 +11,7 @@ InstallPostfix() {
 	echo -e "[${green}DONE${NC}]\n"
   fi
   
-  echo -n "Installing POP3/IMAP Mail server (Postfix)... "
+  echo -n "Installing SMTP Mail server (Postfix)... "
   echo "postfix postfix/main_mailer_type select Internet Site" | debconf-set-selections
   echo "postfix postfix/mailname string $CFG_HOSTNAME_FQDN" | debconf-set-selections
   apt_install postfix postfix-mysql postfix-doc getmail4

--- a/distros/ubuntu-16.10/install_mta.sh
+++ b/distros/ubuntu-16.10/install_mta.sh
@@ -5,7 +5,7 @@
 InstallMTA() {
   case $CFG_MTA in
 	"courier")
-	  echo -n "Installing SMTP Mail server (Courier) and Mail signing (OpenDKIM, OpenDMARC)... ";
+	  echo -n "Installing POP3/IMAP Mail server (Courier) and Mail signing (OpenDKIM, OpenDMARC)... ";
 	  echo "courier-base courier-base/webadmin-configmode boolean false" | debconf-set-selections
 	  echo "courier-ssl courier-ssl/certnotice note" | debconf-set-selections
 	  apt_install courier-authdaemon courier-authlib-mysql courier-pop courier-pop-ssl courier-imap courier-imap-ssl libsasl2-2 libsasl2-modules libsasl2-modules-sql sasl2-bin libpam-mysql courier-maildrop opendkim opendkim-tools opendmarc
@@ -28,7 +28,7 @@ InstallMTA() {
 	  echo -e "[${green}DONE${NC}]\n"
 	  ;;
 	"dovecot")
-	  echo -n "Installing SMTP Mail server (Dovecot) and Mail signing (OpenDKIM, OpenDMARC)... ";
+	  echo -n "Installing POP3/IMAP Mail server (Dovecot) and Mail signing (OpenDKIM, OpenDMARC)... ";
 	  echo "dovecot-core dovecot-core/create-ssl-cert boolean false" | debconf-set-selections
 	  echo "dovecot-core dovecot-core/ssl-cert-name string $CFG_HOSTNAME_FQDN" | debconf-set-selections
 	  apt_install dovecot-imapd dovecot-pop3d dovecot-mysql dovecot-sieve dovecot-lmtpd opendkim opendkim-tools opendmarc

--- a/distros/ubuntu-16.10/install_postfix.sh
+++ b/distros/ubuntu-16.10/install_postfix.sh
@@ -11,7 +11,7 @@ InstallPostfix() {
 	echo -e "[${green}DONE${NC}]\n"
   fi
   
-  echo -n "Installing POP3/IMAP Mail server (Postfix)... "
+  echo -n "Installing SMTP Mail server (Postfix)... "
   echo "postfix postfix/main_mailer_type select Internet Site" | debconf-set-selections
   echo "postfix postfix/mailname string $CFG_HOSTNAME_FQDN" | debconf-set-selections
   apt_install postfix postfix-mysql postfix-doc getmail4

--- a/distros/ubuntu-18.04/install_mta.sh
+++ b/distros/ubuntu-18.04/install_mta.sh
@@ -5,7 +5,7 @@
 InstallMTA() {
   case $CFG_MTA in
 	"courier")
-	  echo -n "Installing SMTP Mail server (Courier) and Mail signing (OpenDKIM, OpenDMARC)... ";
+	  echo -n "Installing POP3/IMAP Mail server (Courier) and Mail signing (OpenDKIM, OpenDMARC)... ";
 	  echo "courier-base courier-base/webadmin-configmode boolean false" | debconf-set-selections
 	  echo "courier-ssl courier-ssl/certnotice note" | debconf-set-selections
 	  apt_install courier-authdaemon courier-authlib-mysql courier-pop courier-pop-ssl courier-imap courier-imap-ssl libsasl2-2 libsasl2-modules libsasl2-modules-sql sasl2-bin libpam-mysql courier-maildrop opendkim opendkim-tools opendmarc
@@ -28,7 +28,7 @@ InstallMTA() {
 	  echo -e "[${green}DONE${NC}]\n"
 	  ;;
 	"dovecot")
-	  echo -n "Installing SMTP Mail server (Dovecot) and Mail signing (OpenDKIM, OpenDMARC)... ";
+	  echo -n "Installing POP3/IMAP Mail server (Dovecot) and Mail signing (OpenDKIM, OpenDMARC)... ";
 	  echo "dovecot-core dovecot-core/create-ssl-cert boolean false" | debconf-set-selections
 	  echo "dovecot-core dovecot-core/ssl-cert-name string $CFG_HOSTNAME_FQDN" | debconf-set-selections
 	  apt_install dovecot-imapd dovecot-pop3d dovecot-mysql dovecot-sieve dovecot-lmtpd opendkim opendkim-tools opendmarc

--- a/distros/ubuntu-18.04/install_postfix.sh
+++ b/distros/ubuntu-18.04/install_postfix.sh
@@ -11,7 +11,7 @@ InstallPostfix() {
 	echo -e "[${green}DONE${NC}]\n"
   fi
   
-  echo -n "Installing POP3/IMAP Mail server (Postfix)... "
+  echo -n "Installing SMTP Mail server (Postfix)... "
   echo "postfix postfix/main_mailer_type select Internet Site" | debconf-set-selections
   echo "postfix postfix/mailname string $CFG_HOSTNAME_FQDN" | debconf-set-selections
   apt_install postfix postfix-mysql postfix-doc getmail4


### PR DESCRIPTION
Replace 'SMPT' with 'SMTP' on install scripts.