### PR TITLE
Update install_hhvm.sh

### DIFF
--- a/distros/debian9/install_hhvm.sh
+++ b/distros/debian9/install_hhvm.sh
@@ -1,8 +1,8 @@
 InstallHHVM() {
   if [ $CFG_SETUP_WEB = "yes" ]; then
     echo -n "Installing HHVM (Hip Hop Virtual Machine)... "
-    apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449
-    echo deb http://dl.hhvm.com/debian jessie main | tee /etc/apt/sources.list.d/hhvm.list
+    apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
+    echo deb http://dl.hhvm.com/debian stretch main | tee /etc/apt/sources.list.d/hhvm.list
     hide_output apt-get update
     apt_install hhvm
     echo -e "[${green}DONE${NC}]\n"


### PR DESCRIPTION
Changed to current way of adding HHVM. The current one does not work without the jessie backports package server setup.

https://docs.hhvm.com/hhvm/installation/linux#debian-8-jessie-debian-9-stretch