### PR TITLE
Update install_quota.sh

### DIFF
--- a/distros/debian9/install_quota.sh
+++ b/distros/debian9/install_quota.sh
@@ -6,9 +6,10 @@ InstallQuota() {
 	echo -n "Installing Quota... "
 	apt_install quota quotatool
 	echo -e "[${green}DONE${NC}]\n"
+	quotaoff -a
 
 	if ! [ -f /proc/user_beancounters ]; then
-		echo -n "Initializing Quota, this may take awhile... "
+		echo -n "Initializing Quota, this may take a while... "
 		if [ "$(grep -c ',usrjquota=quota.user,grpjquota=quota.group,jqfmt=vfsv0' /etc/fstab)" -eq 0 ]; then
 			sed -i '/\/[[:space:]]\+/ {/tmpfs/!s/errors=remount-ro/errors=remount-ro,usrjquota=quota.user,grpjquota=quota.group,jqfmt=vfsv0/}' /etc/fstab
 			sed -i '/\/[[:space:]]\+/ {/tmpfs/!s/defaults/defaults,usrjquota=quota.user,grpjquota=quota.group,jqfmt=vfsv0/}' /etc/fstab


### PR DESCRIPTION
Turn off quota to avoid:
Initializing Quota, this may take awhile... quotacheck: Quota for users is enabled on mountpoint / so quotacheck might damage the file.
Please turn quotas off or use -f to force checking.
quotaon: using //quota.group on /dev/md1 [/]: Device or resource busy
quotaon: using //quota.user on /dev/md1 [/]: Device or resource busy