### PR TITLE
Update install_fail2ban.sh

### DIFF
--- a/distros/ubuntu-18.04/install_fail2ban.sh
+++ b/distros/ubuntu-18.04/install_fail2ban.sh
@@ -108,7 +108,12 @@ failregex = .*pure-ftpd: \(.*@<HOST>\) \[WARNING\] Authentication failed for use
 ignoreregex =
 EOF
 
-echo "ignoreregex =" >> /etc/fail2ban/filter.d/postfix-sasl.conf
+cat > /etc/fail2ban/filter.d/postfix-sasl.conf <<EOF
+[Definition]
+ignoreregex =
+
+EOF
+
 
   echo -e "[${green}DONE${NC}]\n"
   echo -n "Restarting Fail2Ban... "


### PR DESCRIPTION
On my Ubuntu 18.04.2 LTS fail2ban failed to start: 

Feb 25 11:04:00  systemd[1]: Starting Fail2Ban Service...
Feb 25 11:04:00  systemd[1]: Started Fail2Ban Service.
Feb 25 11:04:00  fail2ban-server[22920]:  Failed during configuration: File contains no section headers.
Feb 25 11:04:00  fail2ban-server[22920]: file: '/etc/fail2ban/filter.d/postfix-sasl.conf', line: 1
Feb 25 11:04:00  fail2ban-server[22920]: 'ignoreregex =\n'
Feb 25 11:04:00  fail2ban-server[22920]:  Async configuration of server failed
Feb 25 11:04:00  systemd[1]: fail2ban.service: Main process exited, code=exited, status=255/n/a
Feb 25 11:04:00  systemd[1]: fail2ban.service: Failed with result 'exit-code'.

This commit fixed the issue.