### PR TITLE
Fix typo preventing installation of metronome

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -283,7 +283,7 @@ if [ -f /etc/debian_version ]; then
 		fi
 		if [ "$CFG_METRONOME" == "yes" ]; then
 			source $APWD/distros/$DISTRO/install_metronome.sh
-			Installmetronome
+			InstallMetronome
 		fi
 		if [ "$CFG_WEBMAIL" != "no" ]; then
 			InstallWebmail 


### PR DESCRIPTION
Fixing error: ./install.sh: line 286: Installmetronome: command not found